### PR TITLE
Feat: intégration du bouton de connexion Cognito

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -6,8 +6,20 @@ import { defineAuth } from "@aws-amplify/backend";
  */
 
 export const auth = defineAuth({
-    loginWith: {
-        email: true,
-        // ou phone: true si besoin
-    },
+  loginWith: {
+    email: true,
+    // ou phone: true si besoin
+    externalProviders: {
+      callbackUrls: [
+        "https://peur-de-la-conduite.fr/auth/callback",
+        "https://desktop.peur-de-la-conduite.fr/auth/callback",
+        "https://mobile.peur-de-la-conduite.fr/auth/callback"
+      ],
+      logoutUrls: [
+        "https://peur-de-la-conduite.fr/auth/callback",
+        "https://desktop.peur-de-la-conduite.fr/auth/callback",
+        "https://mobile.peur-de-la-conduite.fr/auth/callback"
+      ]
+    }
+  }
 });

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,0 +1,3 @@
+export default function AuthCallback() {
+  return null;
+}

--- a/src/components/auth/ConnectionButton.tsx
+++ b/src/components/auth/ConnectionButton.tsx
@@ -1,19 +1,29 @@
 "use client";
 
-import { Auth } from "aws-amplify";
+import { useEffect, useRef } from "react";
+import { signInWithRedirect } from "aws-amplify/auth";
 
 export default function ConnectionButton({ label }: { label: string }) {
-    const handleSignIn = () => {
-        Auth.federatedSignIn(); // Cognito Hosted UI
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    const element = linkRef.current;
+    if (!element) return;
+
+    const handleClick = (event: MouseEvent) => {
+      event.preventDefault();
+      signInWithRedirect();
     };
 
-    return (
-        <button
-            type="button"
-            onClick={handleSignIn}
-            className="head-link connection-btn"
-        >
-            <span className="nav-link">{label}</span>
-        </button>
-    );
+    element.addEventListener("click", handleClick);
+    return () => {
+      element.removeEventListener("click", handleClick);
+    };
+  }, []);
+
+  return (
+    <a ref={linkRef} href="#" className="head-link connection-btn">
+      <span className="nav-link">{label}</span>
+    </a>
+  );
 }


### PR DESCRIPTION
## Summary
- configure les URLs de redirection Cognito pour le Hosted UI
- ajoute un bouton de connexion utilisant signInWithRedirect
- crée la page de callback pour l'authentification

## Testing
- `yarn install`
- `yarn lint`
- `yarn build` *(échec : fetch failed pour /blog/[slug])*

------
https://chatgpt.com/codex/tasks/task_e_68abee4cd34c832482695a4d3805c92d