### PR TITLE
[Feat] ajout du fournisseur d'authentification

### DIFF
--- a/src/amplify/amplifyClient.ts
+++ b/src/amplify/amplifyClient.ts
@@ -1,0 +1,13 @@
+import { Amplify } from "aws-amplify";
+
+export function configureAmplify() {
+  Amplify.configure({
+    Auth: {
+      Cognito: {
+        userPoolId: "eu-west-3_cVrLIne9H",
+        userPoolClientId: "2o648gc7uffevblkuj47lnrfaq",
+        loginWith: { email: true },
+      },
+    },
+  });
+}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReactNode, createContext, useContext, useEffect, useMemo, useState } from "react";
+import { Hub } from "aws-amplify/utils";
+import { getCurrentUser, signOut } from "aws-amplify/auth";
+import { configureAmplify } from "@src/amplify/amplifyClient";
+
+interface AuthContextValue {
+  user: unknown | null;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<unknown | null>(null);
+
+  useEffect(() => {
+    configureAmplify();
+
+    const fetchUser = async () => {
+      try {
+        const current = await getCurrentUser();
+        setUser(current);
+      } catch {
+        setUser(null);
+      }
+    };
+
+    fetchUser();
+
+    const unsubscribe = Hub.listen("auth", () => {
+      fetchUser();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  const value = useMemo(() => ({ user, signOut }), [user]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Description
- ajoute un `AuthProvider` basé sur AWS Amplify pour exposer `user` et `signOut` via contexte
- crée un client Amplify dédié à la configuration de Cognito

## Tests effectués
- `yarn install`
- `yarn lint`
- `yarn dlx prettier --write src/components/auth/AuthProvider.tsx src/amplify/amplifyClient.ts` *(échoue : 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abfc0866dc8324be5d5dd163224c2e