### PR TITLE
[Feat] gestion du callback d'authentification

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,3 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
 export default function AuthCallback() {
-  return null;
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const { handleSignIn } = ((await import(
+        "aws-amplify/auth"
+      )) as unknown) as {
+        handleSignIn: () => Promise<void>;
+      };
+      await handleSignIn();
+      router.replace("/");
+    })();
+  }, [router]);
+
+  return <p>Chargement...</p>;
 }


### PR DESCRIPTION
## Description
- gère le callback d'authentification côté client et redirige vers l'accueil

## Tests effectués
- `yarn lint`
- `yarn build` *(échec : ENETUNREACH lors de la génération statique)*

------
https://chatgpt.com/codex/tasks/task_e_68abfecec2888324af1afcdd71f2803c